### PR TITLE
Autobind & Appearance small changes

### DIFF
--- a/lua/autorun/autobind.lua
+++ b/lua/autorun/autobind.lua
@@ -24,6 +24,7 @@ else -- CLIENT
         local frame = vgui.Create("DFrame")
         frame:SetTitle("IMPORTANT!!! PLEASE READ!!!")
         frame:SetSize(400, 250)
+        frame:ShowCloseButton(false)
         frame:Center()
         frame:MakePopup()
 
@@ -58,9 +59,18 @@ Please type 'bind g fake' into your console, which will make G the key you use t
             closeButton:SetEnabled(checked)
         end
 
-        -- Define the action for closeButton (just closes the window)
+        -- Define the action for closeButton
+	    -- Don't allow player to skip this part until he binds `FAKE` - Niik
         closeButton.DoClick = function()
-            frame:Close()
-        end
+		if input.LookupBinding("fake") then
+			if timer.Exists("FakeCheck") then timer.Remove("FakeCheck") frame:Close()
+			else frame:Close() end
+		else
+			closeButton:SetText("[ ◄ BIND G FAKE ► ]")
+			timer.Create("FakeCheck", 2, 0, function() -- resets text back.
+				closeButton:SetText("I'm ready!")
+			end)
+		end
+	end
     end)
 end

--- a/lua/autorun/autobind.lua
+++ b/lua/autorun/autobind.lua
@@ -60,7 +60,7 @@ Please type 'bind g fake' into your console, which will make G the key you use t
         end
 
         -- Define the action for closeButton
-	    -- Don't allow player to skip this part until he binds `FAKE` - Niik
+        -- Don't allow player to skip this part until he binds `FAKE` - Niik
         closeButton.DoClick = function()
 		if input.LookupBinding("fake") then
 			if timer.Exists("FakeCheck") then timer.Remove("FakeCheck") frame:Close()

--- a/lua/homigrad_scr/game/tier_1/appearance/appearance_cl.lua
+++ b/lua/homigrad_scr/game/tier_1/appearance/appearance_cl.lua
@@ -175,6 +175,8 @@ function EasyAppearance.SaveData( tAppearanceData )
 
     file.Write( "homigrad/appearancedata.json", util.TableToJSON( tAppearanceData, true ) )
 
+    --SaveData() should call SendNet(). W/o this - Old skins/mdls are the same as the new for the host - Niik
+	EasyAppearance.SendNet(bRandom, tAppearanceData or {})
 end
 
 function EasyAppearance.GetData( bForceRandom )


### PR DESCRIPTION
Autobind: Warning window cannot be closed in any way until player will bind fake.
Demonstration:
https://github.com/user-attachments/assets/0bece327-55c8-4fdc-a93a-27d52b28d1ea

Appearance: Sync skins/models with server on every change. Applies on PlayerRespawn().
